### PR TITLE
Fix timezone issue in unit test

### DIFF
--- a/test/formatter.spec.js
+++ b/test/formatter.spec.js
@@ -5,7 +5,7 @@ import autoFormatter from "../src/charts/helpers/auto-format"
 describe("Automatic Formatter", () => {
 
   const BASE_NUMBER = 12345.678
-  const BASE_DATE = new Date('Wed, 21 March 2018 00:00:00 GMT')
+  const BASE_DATE = new Date("Wed, 21 March 2018 00:00:00 GMT")
 
   describe("Number formatters", () => {
 
@@ -91,11 +91,11 @@ describe("Automatic Formatter", () => {
 
     it("should handle invalid date formats using js Date default", () => {
       const formatted = autoFormatter("foo")(BASE_DATE)
-      expect(formatted).to.equal("Tue Mar 20 2018 20:00:00 GMT-0400 (EDT)")
+      expect(formatted).to.equal(BASE_DATE.toString())
     })
 
     it("should format using UTC", () => {
-      const date = new Date('Sun, 31 Dec 2017 00:00:00 GMT')
+      const date = new Date("Sun, 31 Dec 2017 00:00:00 GMT")
       const formatted = autoFormatter("%Y-%m-%d")(date)
       expect(formatted).to.equal("2017-12-31")
     })


### PR DESCRIPTION
Use Date#toString in test assertion to generate the timezone-offsetted string for the current platform