### PR TITLE
[FE-11870] Update axis colors to #868686

### DIFF
--- a/dist/mapd3.css
+++ b/dist/mapd3.css
@@ -56,7 +56,7 @@
 
 .mapd3 .axis-group .axis .tick text {
   font-size: 10px;
-  fill: #a7a7a7;
+  fill: #868686;
   padding: 12px; }
 
 .mapd3 .axis-group .y-title, .mapd3 .axis-group .x-title {
@@ -73,7 +73,7 @@
     display: table;
     border-bottom: 1px solid #ddd;
     width: 100%;
-    color: #a7a7a7; }
+    color: #868686; }
   .mapd3 .tooltip-group .tooltip-title-section.collapsed:hover, .mapd3 .legend-group .tooltip-title-section.collapsed:hover {
     cursor: pointer;
     color: #22A7F0; }
@@ -250,7 +250,7 @@
   white-space: nowrap; }
   .mapd3 .label-group .axis-label {
     position: absolute;
-    color: #a7a7a7;
+    color: #868686;
     font-size: 13px;
     overflow: hidden; }
   .mapd3 .label-group .axis-label.x {

--- a/src/styles/charts/label.scss
+++ b/src/styles/charts/label.scss
@@ -6,7 +6,7 @@
 
     .axis-label {
       position: absolute;
-      color: #a7a7a7;
+      color: #868686;
       font-size: 13px;
       overflow: hidden;
     }

--- a/src/styles/common/_axes.scss
+++ b/src/styles/common/_axes.scss
@@ -16,7 +16,7 @@ $tick-size: 1;
         }
         text {
             font-size: 10px;
-            fill: #a7a7a7;
+            fill: #868686;
             padding: $text-padding;
         }
     }

--- a/src/styles/common/_tooltip.scss
+++ b/src/styles/common/_tooltip.scss
@@ -11,7 +11,7 @@
     display: table;
     border-bottom: 1px solid #ddd;
     width: 100%;
-    color: #a7a7a7;
+    color: #868686;
   }
   .tooltip-title-section.collapsed:hover {
     cursor: pointer;


### PR DESCRIPTION
We're updating light mode chart axis colors across the board from #aaa/#a7a7a7 etc to #868686 (which is `$text-gray` in Immerse)

https://omnisci.atlassian.net/browse/FE-11870